### PR TITLE
Aggressively hold desired rangefinder target

### DIFF
--- a/lua/README.md
+++ b/lua/README.md
@@ -1,11 +1,26 @@
-# Surftrak Lua Script
+# Surftrak Lua Scripts
 
-The [surftrak_buttons.lua](surftrak_buttons.lua) script allows you to use the joystick to set the rangefinder target
-to a specific value, and to increment or decrement that value.
+There are 2 surftrak Lua scripts. Both scripts let you set the rangefinder target to a specific value (e.g., 100cm) and
+to increment or decrement the rangefinder target by a specific amount (e.g., 10cm). The 2 scripts differ in how they 
+respond to pilot overrides.
+
+The [surftrak_buttons.lua](surftrak_buttons.lua) script will set or adjust the  rangefinder target only when
+you press the buttons. If you move the sub up or down using the vertical stick, surftrak will automatically adjust the
+rangefinder target to maintain the new altitude. If you want to set the target to 100cm again you can press the button
+again.
+
+In some situations you may need to apply a fair amount of yaw or sway thrust to counteract currents, and so you may end
+up moving the vertical stick by accident. Or you may be moving over a very dynamic seafloor where you have to move up
+and down fairly often. In both cases you may need to pay close attention to the rangefinder target and be ready to
+restore it to 100cm as soon as possible.
+
+The [surftrak2.lua](surftrak2.lua) script lets you specify a _desired_ target, and it will constantly
+update the _current_ rangefinder target as needed, simplifying the process of maintaining a constant distance to the
+seafloor.
 
 > This is experimental and subject to change!
 
-> Be careful using this script! The sub will move at PILOT_SPEED_DN/UP cm / second to achieve the rangefinder target.
+> Be careful! The sub will move at PILOT_SPEED_DN/UP cm / second to achieve the rangefinder target.
 > Even with reasonable settings (PILOT_SPEED_DN = 50 cm/s) I recommend diving under pilot control until you are fairly
 > close to the target, then using the script to set the target exactly.
 
@@ -24,10 +39,10 @@ SCR_USER1 200   # Rangefinder target, in cm
 SCR_USER2 10    # Rangefinder target increment / decrement amount, in cm
 ~~~
 
-The script uses 3 of the 4 _script buttons_. Suggested settings for the Xbox controller:
-* Script button 1 (function 108): Set rangefinder target to `SCR_USER1`
-* Script button 2 (function 109): Increment target by `SCR_USER2`
-* Script button 3 (function 110): Decrement target by `SCR_USER2`
+The script uses 3 of the 4 script buttons:
+* Script button 1 (function 108) sets the rangefinder target to `SCR_USER1`
+* Script button 2 (function 109) increments the target by `SCR_USER2`
+* Script button 3 (function 110) decrements the target by `SCR_USER2`
 
 Suggested settings for the Xbox controller:
 * Map the shift-dpad-right button (`BTN14_SFUNCTION`) to script button 1
@@ -48,14 +63,14 @@ PILOT_SPEED_DN	50    # Max speed down is 50 cm/s
 PILOT_SPEED_UP	50    # Max speed up is 50 cm/s
 ~~~
 
-Copy [surftrak_buttons.lua](surftrak_buttons.lua) to the `/root/.config/blueos/ardupilot-manager/firmware/scripts` folder
+Copy 1 (not both!) of the scripts to the `/root/.config/blueos/ardupilot-manager/firmware/scripts` folder
 in the blueos-core Docker container on the Raspberry Pi. You can do this using BlueOS:
 * Turn on _Pirate mode_
 * Start the _File Browser_
 * Drill into _configs_, _ardupilot-manager_, _firmware_, _scripts_
 * Upload the script to this folder
 
-Reboot ArduSub to load and run the script. You should see "surftrak_buttons.lua running" appear very early in the boot messages.
+Reboot ArduSub to load and run the script. You should see "surftrak2.lua running" appear very early in the boot messages.
 
 ## Pilot Interface
 
@@ -67,7 +82,7 @@ Press shift-dpad-down to decrement the rangefinder target by SCR_USER2.
 
 Each target change will appear in the message list.
 
-Everytime you switch modes the target is forgotten.
+Every time you switch modes the target is forgotten.
 
 The script will run several error checks:
 * If SCR_USER1 is missing or < 50 cm, then you'll see a message every 10s describing the problem

--- a/lua/surftrak2.lua
+++ b/lua/surftrak2.lua
@@ -1,0 +1,87 @@
+--[[
+Similar to surftrak_buttons.lua, but overwrite changes to the rangefinder target.
+
+See lua/README.md file for details.
+]]--
+
+local SURFTRAK_MODE_NUM = 21    -- SURFTRAK mode number
+local LOWER_LIMIT_CM = 50       -- Minimum rangefinder target
+
+local UPDATE_MS = 100           -- Time between updates
+local BAD_PARAM_MS = 10000      -- Use a long update if we are waiting for good parameters
+
+local desired_target            -- The desired rangefinder target
+
+local function set_target(next_target_cm)
+    if next_target_cm < LOWER_LIMIT_CM then
+        gcs:send_text(6, "surftrak_buttons.lua: hit lower limit")
+        next_target_cm = LOWER_LIMIT_CM
+    end
+    sub:set_rangefinder_target_cm(next_target_cm)
+end
+
+local function update()
+    -- Get and clear button counts in all flight modes so that a stale press won't cause confusion later
+    local count_set = sub:get_and_clear_button_count(1)
+    local count_inc = sub:get_and_clear_button_count(2)
+    local count_dec = sub:get_and_clear_button_count(3)
+
+    -- Forget the desired target if we are not in SURFTRAK mode
+    if vehicle:get_mode() ~= SURFTRAK_MODE_NUM and desired_target ~= nil then
+        desired_target = nil
+    end
+
+    -- Silently do nothing if we are in the wrong flight mode or the rangefinder is unhealthy
+    if vehicle:get_mode() ~= SURFTRAK_MODE_NUM or not sub:rangefinder_alt_ok() then
+        return update, UPDATE_MS
+    end
+
+    -- Get and check parameters
+    local action_target_cm = param:get('SCR_USER1')
+    if action_target_cm == nil then
+        gcs:send_text(6, "surftrak_buttons.lua: set SCR_USER1 to rangefinder target, in cm")
+        return update, BAD_PARAM_MS
+    end
+
+    if action_target_cm < LOWER_LIMIT_CM then
+        gcs:send_text(6, "surftrak_buttons.lua: SCR_USER1 is too low")
+        return update, BAD_PARAM_MS
+    end
+
+    local action_inc_cm = param:get('SCR_USER2')
+    if action_inc_cm == nil then
+        gcs:send_text(6, "surftrak_buttons.lua: set SCR_USER2 to rangefinder target increment value, in cm")
+        return update, BAD_PARAM_MS
+    end
+
+    if action_inc_cm < 1 then
+        gcs:send_text(6, "surftrak_buttons.lua: SCR_USER2 must be 1 (1cm) or more")
+        return update, BAD_PARAM_MS
+    end
+
+    -- Set or change the desired target
+    if count_set > 0 then
+        desired_target = action_target_cm
+    else
+        if desired_target ~= nil then
+            local net_inc = count_inc - count_dec
+            if net_inc ~= 0 then
+                desired_target = desired_target + net_inc * action_inc_cm
+            end
+        end
+    end
+
+    -- Apply the desired target
+    if desired_target ~= nil then
+        local curr_target_cm = sub:get_rangefinder_target_cm()
+        if curr_target_cm ~= desired_target then
+            set_target(desired_target)
+        end
+    end
+
+    return update, UPDATE_MS
+end
+
+gcs:send_text(6, "surftrak2.lua running")
+
+return update()

--- a/lua/surftrak2.lua
+++ b/lua/surftrak2.lua
@@ -31,8 +31,8 @@ local function update()
         desired_target = nil
     end
 
-    -- Silently do nothing if we are in the wrong flight mode or the rangefinder is unhealthy
-    if vehicle:get_mode() ~= SURFTRAK_MODE_NUM or not sub:rangefinder_alt_ok() then
+    -- Silently do nothing if we are disarmed, in the wrong flight mode, or the rangefinder is unhealthy
+    if not arming:is_armed() or vehicle:get_mode() ~= SURFTRAK_MODE_NUM or not sub:rangefinder_alt_ok() then
         return update, UPDATE_MS
     end
 


### PR DESCRIPTION
surftrak2.lua maintains a desired rangefinder target, and aggressively overrides target changes from any other source.

See https://github.com/Seattle-Aquarium/CCR_development/issues/31